### PR TITLE
Fix typo in SCM URL

### DIFF
--- a/reorderable/build.gradle.kts
+++ b/reorderable/build.gradle.kts
@@ -84,7 +84,7 @@ publishing {
                 }
                 scm {
                     connection.set("https://github.com/aclassen/ComposeReorderable.git")
-                    url.set("https://github.com/aclassen/ComposeReorderableI")
+                    url.set("https://github.com/aclassen/ComposeReorderable")
                 }
                 developers {
                     developer {


### PR DESCRIPTION
Found this when Renovate opened a dependency update PR with a link to this project. Renovate is using this string, so it was a 404 URL.