### PR TITLE
Fix infinite recomposition when state properties used in composition

### DIFF
--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableState.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableState.kt
@@ -64,13 +64,13 @@ abstract class ReorderableState<T>(
     internal val interactions = Channel<StartDrag>()
     internal val scrollChannel = Channel<Float>()
     val draggingItemLeft: Float
-        get() = draggingLayoutInfo?.let { item ->
+        get() = if(draggingItemKey!=null) draggingLayoutInfo?.let { item ->
             (selected?.left ?: 0) + draggingDelta.x - item.left
-        } ?: 0f
+        } ?: 0f else 0f
     val draggingItemTop: Float
-        get() = draggingLayoutInfo?.let { item ->
+        get() = if(draggingItemKey!=null) draggingLayoutInfo?.let { item ->
             (selected?.top ?: 0) + draggingDelta.y - item.top
-        } ?: 0f
+        } ?: 0f else 0f
     abstract val isVerticalScroll: Boolean
     private val draggingLayoutInfo: T?
         get() = visibleItemsInfo


### PR DESCRIPTION
Infinite recomposition occurs when state properties such as `draggingItemTop` and `draggingItemLeft` are called within composition. Usecase would be to subscribe on these values via `LaunchedEffect` to customize certain UI behavior like below.

```
val state = rememberReorderableLazyListState(onMove = vm::moveDog, canDragOver = vm::isDogDragEnabled)
LaunchedEffect(
        key1 = state.draggingItemKey,
        key2 = state.draggingItemTop,
        block = {
            Log.d("TAG", "NewVerticalReorderList: ${state.draggingItemTop}")
            if(state.draggingItemTop>50f){
                **// Do call custom logic in here... **
            }
        }
)
LazyColumn(
        state = state.listState,
        modifier = modifier
            .then(Modifier
                .reorderable(state)
                .detectReorderAfterLongPress(state))
)
```

Steps to reproduce this bug is to add the above LaunchedEffect in the sample project. This PR addresses the issue by simply checking the `draggingItemKey` existence. So that this value can only be fetched from `draggingLayoutInfo` only if there is an acitve dragged item.

Here is how hwui rendering looks like under infinite recomposition.

https://user-images.githubusercontent.com/24787115/185813307-9862b92d-de35-42da-9e20-b6da53852b81.mov