### PR TITLE
Support for selected item in canDragOver

### DIFF
--- a/android/src/main/kotlin/org/burnoutcrew/android/ui/reorderlist/ImageListViewModel.kt
+++ b/android/src/main/kotlin/org/burnoutcrew/android/ui/reorderlist/ImageListViewModel.kt
@@ -33,5 +33,5 @@ class ImageListViewModel : ViewModel() {
         }
     }
 
-    fun canDragOver(pos: ItemPosition) = images.any { it == pos.key }
+    fun canDragOver(draggedOver: ItemPosition, dragging: ItemPosition) = images.any { it == draggedOver.key }
 }

--- a/android/src/main/kotlin/org/burnoutcrew/android/ui/reorderlist/ReorderListViewModel.kt
+++ b/android/src/main/kotlin/org/burnoutcrew/android/ui/reorderlist/ReorderListViewModel.kt
@@ -39,5 +39,5 @@ class ReorderListViewModel : ViewModel() {
         }
     }
 
-    fun isDogDragEnabled(pos: ItemPosition) = dogs.getOrNull(pos.index)?.isLocked != true
+    fun isDogDragEnabled(draggedOver: ItemPosition, dragging: ItemPosition) = dogs.getOrNull(draggedOver.index)?.isLocked != true
 }

--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyGridState.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyGridState.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.CoroutineScope
 fun rememberReorderableLazyGridState(
     onMove: (ItemPosition, ItemPosition) -> Unit,
     gridState: LazyGridState = rememberLazyGridState(),
-    canDragOver: ((index: ItemPosition) -> Boolean)? = null,
+    canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     maxScrollPerFrame: Dp = 20.dp,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
@@ -62,7 +62,7 @@ class ReorderableLazyGridState(
     scope: CoroutineScope,
     maxScrollPerFrame: Float,
     onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> (Unit),
-    canDragOver: ((index: ItemPosition) -> Boolean)? = null,
+    canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
 ) : ReorderableState<LazyGridItemInfo>(scope, maxScrollPerFrame, onMove, canDragOver, onDragEnd, dragCancelledAnimation) {

--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyListState.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableLazyListState.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.CoroutineScope
 fun rememberReorderableLazyListState(
     onMove: (ItemPosition, ItemPosition) -> Unit,
     listState: LazyListState = rememberLazyListState(),
-    canDragOver: ((index: ItemPosition) -> Boolean)? = null,
+    canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     maxScrollPerFrame: Dp = 20.dp,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
@@ -72,7 +72,7 @@ class ReorderableLazyListState(
     scope: CoroutineScope,
     maxScrollPerFrame: Float,
     onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> (Unit),
-    canDragOver: ((index: ItemPosition) -> Boolean)? = null,
+    canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)? = null,
     onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))? = null,
     dragCancelledAnimation: DragCancelledAnimation = SpringDragCancelledAnimation()
 ) : ReorderableState<LazyListItemInfo>(

--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableState.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableState.kt
@@ -40,7 +40,7 @@ abstract class ReorderableState<T>(
     private val scope: CoroutineScope,
     private val maxScrollPerFrame: Float,
     private val onMove: (fromIndex: ItemPosition, toIndex: ItemPosition) -> (Unit),
-    private val canDragOver: ((index: ItemPosition) -> Boolean)?,
+    private val canDragOver: ((draggedOver: ItemPosition, dragging: ItemPosition) -> Boolean)?,
     private val onDragEnd: ((startIndex: Int, endIndex: Int) -> (Unit))?,
     val dragCancelledAnimation: DragCancelledAnimation
 ) {
@@ -203,7 +203,7 @@ abstract class ReorderableState<T>(
             ) {
                 return@fastForEach
             }
-            if (canDragOver?.invoke(ItemPosition(item.itemIndex, item.itemKey)) != false) {
+            if (canDragOver?.invoke(ItemPosition(item.itemIndex, item.itemKey), ItemPosition(selected.itemIndex, selected.itemKey)) != false) {
                 val dx = (centerX - (item.left + item.right) / 2).absoluteValue
                 val dy = (centerY - (item.top + item.bottom) / 2).absoluteValue
                 val dist = dx * dx + dy * dy


### PR DESCRIPTION
Motivation:

I use LazyGrid for two types of items: categories and items. I am allow to reorder categories and items separetly but those two should never mixed up. My goal was is use `canDragOver` with return false if item A and B have different type (category, item). I hope it justifies the pull request. 

**Possible implementation:**

```kotlin
  private fun Any?.type() = (this as String).split("_").first()

  val state = rememberReorderableLazyGridState(
      onDragEnd = { 
              from, to -> vm.onDragEnd()
      },
      canDragOver = { 
              draggedOver, dragging -> draggedOver.key.type() == dragging.key.type() 
      },
      onMove = { from, to ->
          val itemsBefore = data.activities.size + 1

          when {
              from.key.type() == "activity" && to.key.type() == "activity" -> vm.onMoveActivity(
                  from.index - 1,
                  to.index - 1
              )
              from.key.type() == "group" && to.key.type() == "group" -> vm.onMoveGroup(
                  from.index - itemsBefore,
                  to.index - itemsBefore
              )
              else -> throw IllegalArgumentException()
          }
      }
  )
```
**Layout for reference:**

![Screenshot_20221021-195612](https://user-images.githubusercontent.com/18723841/197259288-897a3b41-d8f1-4356-a578-1f3a05e96bf3.png)

