### PR TITLE
docs: add KDoc and license header to ItemPosition

### DIFF
--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ItemPosition.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ItemPosition.kt
@@ -1,3 +1,24 @@
+/*
+ * Copyright 2022 André Claßen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.burnoutcrew.reorderable
 
+/**
+ * Represents the position of an item within a reorderable list or grid.
+ *
+ * @param index The zero-based index of the item in the list or grid.
+ * @param key The stable key of the item, or null when using index-only lists.
+ */
 data class ItemPosition(val index: Int, val key: Any?)


### PR DESCRIPTION
## Summary
- Add Apache 2.0 license header to `ItemPosition.kt` for consistency with other public API files
- Document `index` and `key` fields with KDoc

## Test plan
- [x] `./gradlew :reorderable:compileKotlinJvm` passes
