### PR TITLE
feat: expose defaultDraggingModifier on grid ReorderableItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fun VerticalReorderList() {
         .detectReorderAfterLongPress(state)
     ) {
         items(data.value, { it }) { item ->
-            ReorderableItem(state, key = item) { isDragging ->
+            ReorderableItem(state, key = item, defaultDraggingModifier = Modifier) { isDragging ->
                 val elevation = animateDpAsState(if (isDragging) 16.dp else 0.dp)
                 Column(
                     modifier = Modifier

--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableItem.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/ReorderableItem.kt
@@ -40,8 +40,9 @@ fun LazyGridItemScope.ReorderableItem(
     key: Any?,
     modifier: Modifier = Modifier,
     index: Int? = null,
+    defaultDraggingModifier: Modifier = Modifier.animateItem(),
     content: @Composable BoxScope.(isDragging: Boolean) -> Unit
-) = ReorderableItem(reorderableState, key, modifier, Modifier.animateItem(), false, index, content)
+) = ReorderableItem(reorderableState, key, modifier, defaultDraggingModifier, false, index, content)
 
 @Composable
 fun ReorderableItem(


### PR DESCRIPTION
## Summary
- Add `defaultDraggingModifier` parameter to `LazyGridItemScope.ReorderableItem`, matching the list overload API
- Update README grid example to demonstrate disabling the default animate modifier

## Test plan
- [x] `./gradlew :reorderable:compileKotlinJvm` passes
- [x] Verified README grid snippet compiles with the new parameter
