### PR TITLE
chore: add CONTRIBUTING guide, modernize CI, and fix minor metadata

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,30 +5,26 @@ on:
     branches: [ main ]
 
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           fetch-depth: '0'
 
-      - name: Check out java
-        uses: actions/setup-java@v2
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Run Checks
         run: ./gradlew check
 
       - name: Upload reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to ComposeReorderable
+
+Thank you for your interest in contributing!
+
+## Prerequisites
+
+- JDK 11 or later
+- Android SDK (for building the `:android` sample app)
+
+## Building the project
+
+Clone the repository and run:
+
+```bash
+./gradlew :reorderable:compileKotlinJvm
+./gradlew :android:assembleDebug
+./gradlew :desktop:run
+```
+
+To run the full check suite (includes JS targets):
+
+```bash
+./gradlew check
+```
+
+> **Note:** Publishing the `reorderable` library requires `ossrh.Username` and `ossrh.Password` credentials in `gradle.properties`. Local development does not need these.
+
+## Making changes
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your changes in the `reorderable` module or sample apps.
+3. Verify your changes compile:
+
+   ```bash
+   ./gradlew :reorderable:compileKotlinJvm :android:assembleDebug
+   ```
+
+4. Open a pull request against `main` with a clear description of the change and how to test it.
+
+## Code style
+
+- Follow [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html).
+- Match the existing style and structure of the module you are editing.
+- Keep changes focused — one logical improvement per pull request.
+
+## Reporting issues
+
+Please use the [GitHub issue tracker](https://github.com/aclassen/ComposeReorderable/issues) to report bugs or request features. Include steps to reproduce, expected behavior, and your Compose/Kotlin versions when reporting bugs.

--- a/reorderable/build.gradle.kts
+++ b/reorderable/build.gradle.kts
@@ -52,7 +52,7 @@ publishing {
             artifact(javadocJar)
             pom {
                 name.set("ComposeReorderable")
-                description.set("Reorderable Compose LazyList")
+                description.set("Reorderable Compose LazyList and LazyGrid")
                 licenses {
                     license {
                         name.set("Apache-2.0")

--- a/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/DragGesture.kt
+++ b/reorderable/src/commonMain/kotlin/org/burnoutcrew/reorderable/DragGesture.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.util.fastFirstOrNull
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 
-// Copied from DragGestureDetector , as long the pointer api isn`t ready.
+// Copied from DragGestureDetector, as long as the pointer api isn't ready.
 
 internal suspend fun AwaitPointerEventScope.awaitPointerSlopOrCancellation(
     pointerId: PointerId,


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with build instructions and PR guidelines
- Update GitHub Actions workflow to current action versions (`checkout@v4`, `setup-java@v4` with Temurin, `upload-artifact@v4`)
- Fix comment typo in `DragGesture.kt`
- Update Maven POM description to mention LazyGrid support

## Test plan
- [x] `./gradlew :reorderable:compileKotlinJvm :android:assembleDebug` passes
- [x] Reviewed CONTRIBUTING.md build steps locally
